### PR TITLE
feat(qwen_lora): add Nunchaku Qwen Image LoRA Stack V4 with rgthree-style UI

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -38,6 +38,7 @@ try:
     from .nodes.lora.qwenimage import NunchakuQwenImageLoraLoader, NunchakuQwenImageLoraStack
     from .nodes.lora.qwenimage_v2 import GENERATED_NODES as QWEN_V2_NODES, GENERATED_DISPLAY_NAMES as QWEN_V2_NAMES
     from .nodes.lora.qwenimage_v3 import GENERATED_NODES as QWEN_V3_NODES, GENERATED_DISPLAY_NAMES as QWEN_V3_NAMES
+    from .nodes.lora.qwenimage_v4 import GENERATED_NODES as QWEN_V4_NODES, GENERATED_DISPLAY_NAMES as QWEN_V4_NAMES
     from .nodes.lora.zimageturbo_v2 import GENERATED_NODES as ZIMAGETURBO_V2_NODES, GENERATED_DISPLAY_NAMES as ZIMAGETURBO_V2_NAMES
     # Z-Image-Turbo V3 is deprecated - removed from registration
     # from .nodes.lora.zimageturbo_v3 import GENERATED_NODES as ZIMAGETURBO_V3_NODES, GENERATED_DISPLAY_NAMES as ZIMAGETURBO_V3_NAMES
@@ -49,6 +50,8 @@ try:
     for node_class in QWEN_V2_NODES.values():
         node_class.__version__ = __version__
     for node_class in QWEN_V3_NODES.values():
+        node_class.__version__ = __version__
+    for node_class in QWEN_V4_NODES.values():
         node_class.__version__ = __version__
     for node_class in ZIMAGETURBO_V2_NODES.values():
         node_class.__version__ = __version__
@@ -62,6 +65,7 @@ try:
     NODE_CLASS_MAPPINGS["NunchakuQwenImageLoraStack"] = NunchakuQwenImageLoraStack
     NODE_CLASS_MAPPINGS.update(QWEN_V2_NODES)
     NODE_CLASS_MAPPINGS.update(QWEN_V3_NODES)
+    NODE_CLASS_MAPPINGS.update(QWEN_V4_NODES)
     NODE_CLASS_MAPPINGS.update(ZIMAGETURBO_V2_NODES)
     # Z-Image-Turbo V3 registration removed
     # NODE_CLASS_MAPPINGS.update(ZIMAGETURBO_V3_NODES)
@@ -74,6 +78,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "NunchakuQwenImageLoraStack": "Nunchaku Qwen Image LoRA Stack (Legacy)",
     **QWEN_V2_NAMES,
     **QWEN_V3_NAMES,
+    **QWEN_V4_NAMES,
     **ZIMAGETURBO_V2_NAMES,
     # Z-Image-Turbo V3 registration removed
     # **ZIMAGETURBO_V3_NAMES,

--- a/js/z_qwen_lora_dynamic_v4.js
+++ b/js/z_qwen_lora_dynamic_v4.js
@@ -1,0 +1,344 @@
+import { app } from "../../scripts/app.js";
+import { api } from "../../scripts/api.js";
+
+console.log("★★★ z_qwen_lora_dynamic_v4.js: Qwen Image LoRA Stack V4 ★★★");
+
+// Use LiteGraph built-in colors to ensure Light/Dark Mode compatibility
+const getColors = () => ({
+  bg: LiteGraph.WIDGET_BGCOLOR,
+  text: LiteGraph.WIDGET_TEXT_COLOR,
+  secondary: LiteGraph.WIDGET_SECONDARY_TEXT_COLOR,
+  outline: LiteGraph.WIDGET_OUTLINE_COLOR,
+  active: LiteGraph.NODE_SELECTED_TITLE_COLOR,
+});
+
+const WIDGET_HEIGHT = 24;
+const HORIZ_MARGIN = 15;
+
+class NunchakuLoraWidget {
+  constructor(name, parentNode) {
+    this.name = name;
+    this.type = "custom";
+    this.parentNode = parentNode;
+    this.value = { enabled: true, lora_name: "None", lora_strength: 1.0 };
+    this.last_y = 0;
+
+    // Define hit areas
+    this.hitAreas = {
+      toggle: [0, 0],
+      lora: [0, 0],
+      strengthDec: [0, 0],
+      strengthInc: [0, 0],
+      strengthVal: [0, 0]
+    };
+  }
+
+  draw(ctx, node, width, posY, height) {
+    const colors = getColors();
+    const x = HORIZ_MARGIN;
+    const midY = posY + height / 2;
+    this.last_y = posY;
+    const widgetWidth = width - HORIZ_MARGIN * 2;
+
+    // --- Check global stack enabled state ---
+    const globalOn = node.widgets.find(w => w.name === "stack_enabled")?.value !== false;
+    const effectiveOn = this.value.enabled && globalOn;
+
+    ctx.save();
+
+    // 1. Background - using theme colors
+    ctx.fillStyle = colors.bg;
+    ctx.strokeStyle = colors.outline;
+    ctx.beginPath();
+    ctx.roundRect(x, posY + 2, widgetWidth, height - 4, [4]);
+    ctx.fill();
+    ctx.stroke();
+
+    // 2. Toggle switch
+    const toggleWidth = 20;
+    const toggleHeight = 12;
+    const toggleX = x + 8;
+    const toggleY = midY - (toggleHeight / 2);
+
+    // Track background
+    ctx.fillStyle = colors.outline;
+    ctx.beginPath();
+    ctx.roundRect(toggleX, toggleY, toggleWidth, toggleHeight, [toggleHeight / 2]);
+    ctx.fill();
+
+    // Knob
+    ctx.fillStyle = globalOn ? colors.text : colors.secondary; // Knob follows global state
+    ctx.beginPath();
+    // Position knob with smaller offsets to stay within the compact track
+    const knobX = this.value.enabled ? toggleX + toggleWidth - 6 : toggleX + 6;
+    ctx.arc(knobX, midY, 4, 0, Math.PI * 2); // Radius reduced to 4
+    ctx.fill();
+    this.hitAreas.toggle = [toggleX, toggleX + toggleWidth];
+
+    // 3. LoRA Name (auto-calculate remaining width)
+    const strengthAreaWidth = 70;
+    const labelX = toggleX + toggleWidth + 10;
+    const labelWidth = widgetWidth - (labelX - x) - strengthAreaWidth - 5;
+
+    ctx.fillStyle = effectiveOn ? colors.text : colors.secondary;
+    ctx.font = "12px Arial";
+    ctx.textAlign = "left";
+    let displayLabel = (this.value.lora_name || "None");
+
+    // Text clipping
+    const metrics = ctx.measureText(displayLabel);
+    if (metrics.width > labelWidth) {
+      const avgCharWidth = 7;
+      const maxChars = Math.floor(labelWidth / avgCharWidth);
+      if (displayLabel.length > maxChars) {
+        displayLabel = displayLabel.substring(0, maxChars - 3) + "...";
+      }
+    }
+    ctx.fillText(displayLabel, labelX, midY + 4);
+    this.hitAreas.lora = [labelX, labelX + labelWidth];
+
+    // 4. Strength control
+    const rightX = x + widgetWidth - 5;
+    const valueCenter = rightX - 35; // Center point for the numeric value
+    const arrowGap = 22;            // Distance from center to arrows
+
+    ctx.textAlign = "center";
+
+    // ▶ symbol
+    ctx.fillText("▶", valueCenter + arrowGap, midY + 4);
+    this.hitAreas.strengthInc = [valueCenter + arrowGap - 10, valueCenter + arrowGap + 10];
+
+    // Numeric value
+    ctx.fillStyle = effectiveOn ? colors.text : colors.secondary;
+    const valStr = this.value.lora_strength.toFixed(2);
+    ctx.fillText(valStr, valueCenter, midY + 4);
+    this.hitAreas.strengthVal = [valueCenter - 18, valueCenter + 18];
+
+    // ◀ symbol
+    ctx.fillText("◀", valueCenter - arrowGap, midY + 4);
+    this.hitAreas.strengthDec = [valueCenter - arrowGap - 10, valueCenter - arrowGap + 10];
+
+    ctx.restore();
+  }
+
+  mouse(event, pos, node) {
+    if (event.type !== "pointerdown") return false;
+    if (event.button === 2) return false; // Right-click is handled by the node
+
+    // --- Block interaction if global stack enabled is off ---
+    const globalOn = node.widgets.find(w => w.name === "stack_enabled")?.value !== false;
+    if (!globalOn) return false;
+
+    const widgetX = pos[0];
+    // Determine hit area
+    if (widgetX >= this.hitAreas.toggle[0] && widgetX <= this.hitAreas.toggle[1]) {
+      this.value.enabled = !this.value.enabled;
+    } else if (widgetX >= this.hitAreas.lora[0] && widgetX <= this.hitAreas.lora[1]) {
+      this.chooseLora(event);
+    } else if (widgetX >= this.hitAreas.strengthDec[0] && widgetX <= this.hitAreas.strengthDec[1]) {
+      this.value.lora_strength = Math.round((this.value.lora_strength - 0.05) * 100) / 100;
+    } else if (widgetX >= this.hitAreas.strengthInc[0] && widgetX <= this.hitAreas.strengthInc[1]) {
+      this.value.lora_strength = Math.round((this.value.lora_strength + 0.05) * 100) / 100;
+    } else if (widgetX >= this.hitAreas.strengthVal[0] && widgetX <= this.hitAreas.strengthVal[1]) {
+      // Use ComfyUI built-in prompt
+      app.canvas.prompt("Lora Strength", this.value.lora_strength, (v) => {
+        const val = parseFloat(v);
+        if (!isNaN(val)) {
+          this.value.lora_strength = val;
+          node.setDirtyCanvas(true);
+        }
+      }, event);
+    } else {
+      return false;
+    }
+
+    this.parentNode.setDirtyCanvas(true, true);
+    return true;
+  }
+
+  async chooseLora(event) {
+    // Get ComfyUI LoRA list
+    const resp = await api.fetchApi("/object_info");
+    const data = await resp.json();
+    const loras = data?.LoraLoader?.input?.required?.lora_name?.[0] || [];
+
+    // Use LiteGraph's ContextMenu
+    const menu = new LiteGraph.ContextMenu(loras, {
+      event: event,
+      callback: (value) => {
+        this.value.lora_name = value;
+        this.parentNode.setDirtyCanvas(true, true);
+      }
+    });
+  }
+
+  serializeValue() {
+    return this.value;
+  }
+}
+
+app.registerExtension({
+  name: "nunchaku.qwen_lora_dynamic_v4",
+
+  async beforeRegisterNodeDef(nodeType, nodeData, app) {
+    if (nodeData.name !== "NunchakuQwenImageLoraStackV4") return;
+
+    // Save original onNodeCreated
+    const onNodeCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      onNodeCreated?.apply(this, arguments);
+      // Inform ComfyUI to include widget values in the prompt sent to the backend
+      this.serialize_widgets = true;
+      this.loraWidgets = [];
+
+      // Monitor stack_enabled switch
+      const stackEnabledWidget = this.widgets.find(w => w.name === "stack_enabled");
+      if (stackEnabledWidget) {
+        stackEnabledWidget.callback = () => { this.setDirtyCanvas(true); };
+      }
+
+      // Add "Add Lora" button
+      const btn = this.addWidget("button", "➕ Add Lora", null, (val, canvas, node, pos, event) => {
+        this.addLoraRowWithChooser(event);
+      });
+
+      // Prevent the button from being serialized and sent to the backend
+      btn.serialize = false;
+
+      const HEADER_H = 60;
+      const INPUT_WIDGETS_H = stackEnabledWidget ? 50 : 0;
+      const PADDING = 20;
+      const targetH = HEADER_H + INPUT_WIDGETS_H + PADDING;
+      this.setSize([this.size[0], targetH]);
+      if (app.canvas) app.canvas.setDirty(true, true);
+    };
+
+    // Show LoRA menu before adding the row
+    nodeType.prototype.addLoraRowWithChooser = async function (event) {
+      // Fetch LoRA list from ComfyUI object info
+      const resp = await api.fetchApi("/object_info");
+      const data = await resp.json();
+      const loras = data?.LoraLoader?.input?.required?.lora_name?.[0] || [];
+
+      // Show the selection menu
+      new LiteGraph.ContextMenu(loras, {
+        event: event,
+        callback: (value) => {
+          // Add the row only after a LoRA is selected
+          this.addLoraRow({ enabled: true, lora_name: value, lora_strength: 1.0 });
+        }
+      });
+    };
+
+    // Add a new LoRA row
+    nodeType.prototype.addLoraRow = function (data = null) {
+      const name = `lora_${this.loraWidgets.length + 1}`;
+      const w = new NunchakuLoraWidget(name, this);
+      // Ensure we have a default value if no data is provided
+      w.value = data || { enabled: true, lora_name: "None", lora_strength: 1.0 };
+
+      // Insert above the button
+      const btnIdx = this.widgets.findIndex(x => x.name === "➕ Add Lora");
+      this.widgets.splice(btnIdx, 0, w);
+      this.loraWidgets.push(w);
+
+      this.setSize([this.size[0], this.computeSize()[1]]);
+      this.setDirtyCanvas(true, true);
+      return w;
+    };
+
+    // Right-click menu logic
+    // Override getSlotInPosition to detect if a widget was clicked
+    nodeType.prototype.getSlotInPosition = function (canvasX, canvasY) {
+      const slot = LGraphNode.prototype.getSlotInPosition.apply(this, arguments);
+      if (slot) return slot;
+
+      // If no slot was clicked, check if the click was on our LoraWidget
+      const widget = this.widgets.find(w => {
+        return w instanceof NunchakuLoraWidget &&
+          canvasY > (this.pos[1] + w.last_y) &&
+          canvasY < (this.pos[1] + w.last_y + WIDGET_HEIGHT);
+      });
+
+      if (widget) {
+        // Return dummy slot info, which triggers LiteGraph to call getSlotMenuOptions
+        return { widget: widget, output: { type: "LORA_WIDGET" } };
+      }
+      return null;
+    };
+
+    // Show custom menu when the dummy slot is detected
+    nodeType.prototype.getSlotMenuOptions = function (slot) {
+      if (slot && slot.widget instanceof NunchakuLoraWidget) {
+        const widget = slot.widget;
+        return [
+          {
+            content: widget.value.enabled ? "⚫ Toggle Off" : "🟢 Toggle On",
+            callback: () => {
+              widget.value.enabled = !widget.value.enabled;
+              this.setDirtyCanvas(true);
+            }
+          },
+          {
+            content: "⬆️ Move Up",
+            callback: () => this.moveLora(widget, -1)
+          },
+          {
+            content: "⬇️ Move Down",
+            callback: () => this.moveLora(widget, 1)
+          },
+          {
+            content: "🗑️ Remove",
+            callback: () => {
+              const idx = this.widgets.indexOf(widget);
+              this.widgets.splice(idx, 1);
+              this.loraWidgets = this.loraWidgets.filter(lw => lw !== widget);
+              this.setSize([this.size[0], this.computeSize()[1]]);
+              this.setDirtyCanvas(true);
+            }
+          }
+        ];
+      }
+      return LGraphNode.prototype.getSlotMenuOptions?.apply(this, arguments);
+    };
+
+    nodeType.prototype.moveLora = function (widget, dir) {
+      const idx = this.widgets.indexOf(widget);
+      const targetIdx = idx + dir;
+      // Ensure move range stays between LoraWidgets (prevent moving past or onto model/cpu_offload widgets)
+      if (this.widgets[targetIdx] instanceof NunchakuLoraWidget) {
+        this.widgets.splice(idx, 1);
+        this.widgets.splice(targetIdx, 0, widget);
+        this.setDirtyCanvas(true);
+      }
+    };
+
+    // serialized data loading
+    const onConfigure = nodeType.prototype.onConfigure;
+    nodeType.prototype.onConfigure = function (info) {
+      onConfigure?.apply(this, arguments);
+      if (info.widgets_values) {
+        // Clear initialized widgets
+        this.widgets = this.widgets.filter(w => !(w instanceof NunchakuLoraWidget));
+        this.loraWidgets = [];
+
+        // Recover LoRA rows from serialized data
+        // ComfyUI's serialized data may exist in array format
+        info.widgets_values.forEach((val, idx) => {
+          if (val && typeof val === 'object' && val.lora_name !== undefined) {
+            this.addLoraRow(val);
+          }
+        });
+
+        // Make sure the "Add Lora" button stays at the bottom.
+        if (this.addLoraBtn) {
+          const btnIdx = this.widgets.indexOf(this.addLoraBtn);
+          this.widgets.splice(btnIdx, 1);
+          this.widgets.push(this.addLoraBtn);
+        }
+      }
+    };
+  }
+});
+
+

--- a/nodes/lora/qwenimage_v4.py
+++ b/nodes/lora/qwenimage_v4.py
@@ -1,0 +1,249 @@
+"""
+This module provides the :class:`NunchakuQwenImageLoraStackV4` node
+for applying LoRA weights to Nunchaku Qwen Image models within ComfyUI.
+The interface completely mimics the Power Lora Loader from rgthree-comfy(https://github.com/rgthree/rgthree-comfy ),
+supporting dynamic additions and custom widgets.
+"""
+
+import copy
+import logging
+import os
+import sys
+
+# Fix import path for this module
+current_dir = os.path.dirname(os.path.abspath(__file__))
+# Go up 2 levels: nodes/lora -> nodes -> ComfyUI-QwenImageLoraLoader
+lora_loader_dir = os.path.dirname(os.path.dirname(current_dir))
+if lora_loader_dir not in sys.path:
+    sys.path.insert(0, lora_loader_dir)
+    print(f"[DEBUG] Added to sys.path: {lora_loader_dir}")
+    print(f"[DEBUG] wrappers dir exists: {os.path.exists(os.path.join(lora_loader_dir, 'wrappers'))}")
+    print(f"[DEBUG] qwenimage.py exists: {os.path.exists(os.path.join(lora_loader_dir, 'wrappers', 'qwenimage.py'))}")
+
+import folder_paths
+
+# Get log level from environment variable (default to INFO)
+log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+
+# Configure logging
+logging.basicConfig(level=getattr(logging, log_level, logging.INFO), format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+class any_type(str):
+    def __ne__(self, __value: object) -> bool:
+        return False
+
+class FlexibleOptionalInputType(dict):
+    def __contains__(self, key):
+        return True
+    def __getitem__(self, key):
+        return (any_type, {})
+
+class NunchakuQwenImageLoraStackV4:
+    """
+    Node for loading and applying multiple LoRAs to a Nunchaku Qwen Image model with dynamic UI.
+    Built upon V3, V4 not only supports the ComfyUI Nodes 2.0 UI but also pays full homage
+    to the clean and minimalist design of the Power Lora Loader from the rgthree-comfy project.
+    """
+
+    @classmethod
+    def INPUT_TYPES(s):
+        inputs = {
+            "required": {
+                "model": (
+                    "MODEL",
+                    {"tooltip": "The diffusion model to apply LoRAs to."},
+                ),
+                "cpu_offload": (
+                    ["auto", "enable", "disable"],
+                    {
+                        "default": "disable",
+                        "tooltip": "CPU offload setting. 'auto' enables offload when VRAM is low, 'enable' forces offload, 'disable' disables offload.",
+                    },
+                ),
+                "apply_awq_mod": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "Enable manual planar injection for AWQ modulation layers. Fixes noise issues in quantized models. Default is True.",
+                    },
+                ),
+                "stack_enabled": (
+                    "BOOLEAN",
+                    {
+                        "default": True,
+                        "tooltip": "Master Switch: Enable or disable the entire LoRA stack processing.",
+                    },
+                ),
+            },
+            "optional": FlexibleOptionalInputType(), 
+            # Use 'hidden' here to let JS pass dynamic LoRA data
+            "hidden": {
+                "prompt": "PROMPT",
+                "extra_pnginfo": "EXTRA_PNGINFO",
+            },
+        }
+
+        return inputs
+
+    RETURN_TYPES = ("MODEL",)
+    OUTPUT_TOOLTIPS = ("The modified diffusion model with all LoRAs applied.",)
+    FUNCTION = "load_lora_stack"
+    TITLE = "Nunchaku Qwen Image LoRA Stack V4"
+    CATEGORY = "Nunchaku"
+    DESCRIPTION = "Apply multiple LoRAs to a diffusion model in a single node with dynamic UI control."
+
+    def load_lora_stack(self, model, cpu_offload="disable", apply_awq_mod=True, stack_enabled=True, **kwargs):
+        # Dynamic widgets passed from JS will appear in kwargs
+        # Named lora_1, lora_2... with values as dictionaries: {'enabled': bool, 'lora_name': str, 'lora_strength': float}
+        lora_keys = [key for key in kwargs.keys() if key.startswith("lora_")]
+        lora_keys.sort(key=lambda x: int(x.split('_')[-1])) # Ensure numerical sorting
+
+        lora_count = len(lora_keys)
+
+        loras_to_apply = []
+
+        # Log stack_enabled state
+        logger.info(f"[LoRA Stack Status] apply_awq_mod: {apply_awq_mod}")
+        logger.info(f"[LoRA Stack Status] stack_enabled: {stack_enabled}")
+        logger.info(f"[LoRA Stack Status] Processing {lora_count} LoRA slot(s):")
+        
+        for i, key in enumerate(lora_keys):
+            value = kwargs[key]
+            if not isinstance(value, dict):
+                continue
+
+            lora_name = value.get("lora_name", "None")
+            lora_strength = value.get("lora_strength", 1.0)
+            # stack_enabled acts as a Master Switch.
+            # If stack_enabled is False, all LoRAs are disabled.
+            # If stack_enabled is True, we respect the individual 'enabled' state.
+            enabled = stack_enabled and value.get("enabled", True)
+
+            status_parts = []
+            status_parts.append(f"Slot {i}:")
+            if lora_name and lora_name != "None":
+                status_parts.append(f"'{lora_name}'")
+                status_parts.append(f"strength={lora_strength}")
+            else:
+                status_parts.append("(no LoRA selected)")
+
+            status_parts.append(f"stack_enabled={stack_enabled}")
+            status_parts.append(f"enabled_{i}={enabled}")
+
+            if enabled and lora_name and lora_name != "None" and abs(lora_strength) > 1e-5:
+                status_parts.append("→ APPLIED ✓")
+                loras_to_apply.append((lora_name, lora_strength))
+            else:
+                status_parts.append("→ SKIPPED ✗")
+
+            logger.info(f"[LoRA Stack Status] {' | '.join(status_parts)}")
+
+        logger.info(f"[LoRA Stack Status] Summary: {len(loras_to_apply)} LoRA(s) will be applied out of {lora_count} slot(s)")
+
+        if not loras_to_apply:
+            return (model,)
+
+        model_wrapper = model.model.diffusion_model
+
+        # Dynamic import with explicit path manipulation
+        import importlib.util
+
+        lora_loader_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        if lora_loader_dir not in sys.path:
+            sys.path.insert(0, lora_loader_dir)
+
+        spec = importlib.util.spec_from_file_location(
+            "wrappers.qwenimage",
+            os.path.join(lora_loader_dir, "wrappers", "qwenimage.py"),
+        )
+        wrappers_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(wrappers_module)
+        ComfyQwenImageWrapper = wrappers_module.ComfyQwenImageWrapper
+
+        from nunchaku import NunchakuQwenImageTransformer2DModel
+
+        # Debug logging
+        model_wrapper_type_name = type(model_wrapper).__name__
+        model_wrapper_module = type(model_wrapper).__module__
+        logger.info(f"🔍 Model wrapper type: '{model_wrapper_type_name}'")
+        logger.info(f"🔍 Model wrapper module: {model_wrapper_module}")
+        logger.info(f"🔍 Type repr: {repr(type(model_wrapper))}")
+        logger.info(f"🔍 Has 'model' attr? {hasattr(model_wrapper, 'model')}")
+        logger.info(f"🔍 Has 'loras' attr? {hasattr(model_wrapper, 'loras')}")
+
+        # Check if it's already wrapped
+        if hasattr(model_wrapper, "model") and hasattr(model_wrapper, "loras"):
+            logger.info("✅ Model is already wrapped (detected via attributes)")
+            logger.info(f"📦 Current CPU offload setting: '{model_wrapper.cpu_offload_setting}'")
+            if model_wrapper.cpu_offload_setting != cpu_offload:
+                logger.info(f"🔄 Updating CPU offload setting from '{model_wrapper.cpu_offload_setting}' to '{cpu_offload}'")
+                model_wrapper.cpu_offload_setting = cpu_offload
+            
+            # Dynamically update the apply_awq_mod setting.
+            if hasattr(model_wrapper, "apply_awq_mod") and model_wrapper.apply_awq_mod != apply_awq_mod:
+                logger.info(f"🔄 Updating AWQ mod setting from '{model_wrapper.apply_awq_mod}' to '{apply_awq_mod}'")
+                model_wrapper.apply_awq_mod = apply_awq_mod
+            
+            transformer = model_wrapper.model
+        elif model_wrapper_type_name == "NunchakuQwenImageTransformer2DModel" or model_wrapper_type_name.endswith(
+            "NunchakuQwenImageTransformer2DModel"
+        ):
+            logger.info("🔧 Wrapping NunchakuQwenImageTransformer2DModel with ComfyQwenImageWrapper")
+            logger.info(f"📦 Creating ComfyQwenImageWrapper with cpu_offload='{cpu_offload}', apply_awq_mod={apply_awq_mod}")
+            wrapped_model = ComfyQwenImageWrapper(
+                model_wrapper,
+                getattr(model_wrapper, "config", {}),
+                None,  # customized_forward
+                {},  # forward_kwargs
+                cpu_offload,  # cpu_offload_setting
+                4.0,  # vram_margin_gb
+                apply_awq_mod=apply_awq_mod,
+            )
+            model.model.diffusion_model = wrapped_model
+            model_wrapper = wrapped_model
+            transformer = model_wrapper.model
+        else:
+            logger.error(f"❌ Model type mismatch! Type: {model_wrapper_type_name}, Module: {model_wrapper_module}")
+            logger.error("Please use 'Nunchaku Qwen Image DiT Loader'.")
+            raise TypeError(f"This LoRA loader only works with Nunchaku Qwen Image models, but got {model_wrapper_type_name}.")
+
+        # Flux-style deepcopy
+        saved_config = None
+        if hasattr(model, "model") and hasattr(model.model, "model_config"):
+            saved_config = model.model.model_config
+            model.model.model_config = None
+
+        model_wrapper.model = None
+        try:
+            ret_model = copy.deepcopy(model)
+        finally:
+            if saved_config is not None:
+                model.model.model_config = saved_config
+            model_wrapper.model = transformer
+
+        ret_model_wrapper = ret_model.model.diffusion_model
+        if saved_config is not None:
+            ret_model.model.model_config = saved_config
+        ret_model_wrapper.model = transformer
+
+        ret_model_wrapper.loras = model_wrapper.loras.copy()
+
+        for lora_name, lora_strength in loras_to_apply:
+            lora_path = folder_paths.get_full_path_or_raise("loras", lora_name)
+            ret_model_wrapper.loras.append((lora_path, lora_strength))
+            logger.debug(f"LoRA added to stack: {lora_name} (strength={lora_strength})")
+
+        logger.info(f"Total LoRAs in stack: {len(ret_model_wrapper.loras)}")
+        return (ret_model,)
+
+
+GENERATED_NODES = {
+    "NunchakuQwenImageLoraStackV4": NunchakuQwenImageLoraStackV4,
+}
+
+GENERATED_DISPLAY_NAMES = {
+    "NunchakuQwenImageLoraStackV4": "Nunchaku Qwen Image LoRA Stack V4",
+}
+
+


### PR DESCRIPTION
Hi, it is entirely up to you whether to merge this PR. It is not strictly necessary, as the existing functionality is already excellent.
Basically, this is a new Nunchaku Qwen Image LoRA Stack. The only difference from the current version lies in the frontend UI presentation. I was inspired by the design of the Power Lora Loader (rgthree) node, as I really admire his clean and concise frontend interface.
I have ported a similar design to this project, where each LoRA row features a Toggle switch, LoRA Name, and Strength value arranged from left to right.
I have added z_qwen_lora_dynamic_v4.js and qwenimage_v4.py. The "v4" suffix is just a temporary placeholder. I am not sure if "v4" is appropriate, so @ussoewwin, please feel free to rename the files or modify the code as you see fit.
Thanks!

___

- Implement Nunchaku Qwen Image LoRA Stack V4 based on the V3 architecture.
- Redesign the UI to pay homage to rgthree-comfy's Power Lora Loader.

Special thanks to @rgthree for designing such a clean and elegant interface, which served as the inspiration for this version.

<img width="843" height="333" alt="image" src="https://github.com/user-attachments/assets/9f8d07e4-f8c4-4b5f-b2a5-b0e2d9c5ce42" />
